### PR TITLE
Reduce list item margin in blog posts

### DIFF
--- a/src/site/_includes/styles.css
+++ b/src/site/_includes/styles.css
@@ -281,6 +281,10 @@ header nav li:first-child {
   background-color: var(--blue);
 }
 
+.post li {
+  --flow-space: var(--size-400);
+}
+
 .post {
   --flow-space: var(--size-700);
 


### PR DESCRIPTION
The .post class sets --flow-space to 2.36rem (size-700), which list
items were inheriting, making gaps between items far too large. Override
--flow-space to 1rem (size-400) specifically for list items.

https://claude.ai/code/session_011ueLDFiemf4bTU2VjPDuov